### PR TITLE
Wrong port number is reported by Bonjour \"service_uri\" on MacOS"

### DIFF
--- a/cups/dnssd.c
+++ b/cups/dnssd.c
@@ -1075,7 +1075,7 @@ cupsDNSSDServiceAdd(
   }
 
   service->refs[service->num_refs] = service->dnssd->ref;
-  if ((error = DNSServiceRegister(service->refs + service->num_refs, kDNSServiceFlagsShareConnection | kDNSServiceFlagsNoAutoRename, service->if_index, service->name, types, domain, host, port, txtptr ? TXTRecordGetLength(txtptr) : 0, txtptr ? TXTRecordGetBytesPtr(txtptr) : NULL, (DNSServiceRegisterReply)mdns_service_cb, service)) != kDNSServiceErr_NoError)
+  if ((error = DNSServiceRegister(service->refs + service->num_refs, kDNSServiceFlagsShareConnection | kDNSServiceFlagsNoAutoRename, service->if_index, service->name, types, domain, host, htons(port), txtptr ? TXTRecordGetLength(txtptr) : 0, txtptr ? TXTRecordGetBytesPtr(txtptr) : NULL, (DNSServiceRegisterReply)mdns_service_cb, service)) != kDNSServiceErr_NoError)
   {
     if (txtptr)
       TXTRecordDeallocate(txtptr);


### PR DESCRIPTION
In MacOS with MDNSRESPONDER, DNSServiceRegister API takes port number argument in "Network Byte Order".
But in dnssd.c port number is pass in "Host Byte Order", because of which ippserver or ippeveprinter from https://github.com/istopwg/ippsample are advertising wrong port number through bonjour service.

It works fine in Ubuntu Linux, which is using Avahi.

In below picture's left terminal ippserver is run with port number 8631, in right terminal ippfind tool is used to find the "test printer" which is reporting 46881 as port number in service_uri. 46881 is in host byte order, converting it to network byte order will give 8631.

![image](https://user-images.githubusercontent.com/39510455/189901794-63ec1a68-1659-4974-9e97-fedb43823cd4.png)

Please let me know if additional information is required for this pull request.
