### PR TITLE
Use kernel function instead of deprecated GetVersionExA

### DIFF
--- a/cups/usersys.c
+++ b/cups/usersys.c
@@ -522,8 +522,20 @@ cupsSetUserAgent(const char *user_agent)/* I - User-Agent string or `NULL` */
   * Gather Windows version information for the User-Agent string...
   */
 
-  version.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-  GetVersionExA(&version);
+  typedef LONG NTSTATUS, *PNTSTATUS;
+  typedef NTSTATUS(WINAPI * RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+
+  RtlGetVersionPtr RtlGetVersionInternal = (RtlGetVersionPtr)GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion");
+  if (RtlGetVersionInternal)
+  {
+    version.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+    RtlGetVersionInternal((PRTL_OSVERSIONINFOW)&version);
+  }
+  else
+  {
+    ZeroMemory(&version, sizeof(version));
+  }
+
   GetNativeSystemInfo(&sysinfo);
 
   switch (sysinfo.wProcessorArchitecture)


### PR DESCRIPTION
GetVersionExA has its behavior changed in Windows 8 and above anyway, so this is the right way to do it now.