### PR TITLE
Fix typo Unix-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The CUPS library (libcups) provides a common C API for HTTP/HTTPS and IPP
 communications on Unix®-like operating systems and Microsoft Windows®.  It is
 used by many printing-related projects such as [CUPS][CUPS] and [PAPPL][PAPPL].
 This project is part of OpenPrinting's CUPS 3.0 development, which will provide
-a 100% driverless printing system for Unix®-life operating systems.
+a 100% driverless printing system for Unix®-like operating systems.
 
 This version of the CUPS library removes all of the deprecated and obsolete APIs
 from CUPS 2.x and earlier and is *not* binary compatible with older releases.


### PR DESCRIPTION
I think "Unix-life" was meant to be "Unix-like"