### PR TITLE
Add missing header include

### DIFF
--- a/cups/pwg.h
+++ b/cups/pwg.h
@@ -11,6 +11,7 @@
 #ifndef _CUPS_PWG_H_
 #  define _CUPS_PWG_H_
 #  include "base.h"
+#  include "ipp.h"
 #  ifdef __cplusplus
 extern "C" {
 #  endif /* __cplusplus */


### PR DESCRIPTION
The `pwg.h` reference `ipp_t` from `ipp.h` but the header is not included. This is fine when including `cups.h` because it includes the headers in the correct order, but leads to an error when trying to use `pwg.h` first (and confuses the IDE)