### PR TITLE
Missing struct declaration in pwg.h

### DIFF
--- a/cups/base.h
+++ b/cups/base.h
@@ -153,4 +153,11 @@ typedef int64_t ssize_t;			// @private@
 #  else
 #    define _CUPS_NORETURN
 #  endif // _CUPS_HAS_NORETURN
+
+//
+// Forward declare the ipp_t type that is shared accross headers
+//
+
+typedef struct _ipp_s ipp_t;		// IPP request/response data
+
 #endif // !_CUPS_BASE_H_

--- a/cups/ipp.h
+++ b/cups/ipp.h
@@ -493,7 +493,6 @@ typedef enum ipp_tag_e			// Value and group tag values for attributes
 } ipp_tag_t;
 
 typedef unsigned char ipp_uchar_t;	// Unsigned 8-bit integer/character
-typedef struct _ipp_s ipp_t;		// IPP request/response data
 typedef struct _ipp_attribute_s ipp_attribute_t;
 					// IPP attribute
 

--- a/cups/pwg.h
+++ b/cups/pwg.h
@@ -11,6 +11,7 @@
 #ifndef _CUPS_PWG_H_
 #  define _CUPS_PWG_H_
 #  include "base.h"
+#  include "ipp.h"
 #  ifdef __cplusplus
 extern "C" {
 #  endif /* __cplusplus */

--- a/cups/pwg.h
+++ b/cups/pwg.h
@@ -11,7 +11,6 @@
 #ifndef _CUPS_PWG_H_
 #  define _CUPS_PWG_H_
 #  include "base.h"
-#  include "ipp.h"
 #  ifdef __cplusplus
 extern "C" {
 #  endif /* __cplusplus */


### PR DESCRIPTION
The `pwg.h` reference `ipp_t` from `ipp.h` but the header is not included. This is fine when including `cups.h` because it includes the headers in the correct order, but leads to an error when trying to use `pwg.h` first (and confuses the IDE)