### PR TITLE
Add new PWG media sizes (PRC D0-D6, ZL)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ v3.0.3 - YYYY-MM-DD
 - Fixed HTTP state for POST/PUT with an empty message body (Issue #149)
 - Fixed the example RPM spec file (Issue #150)
 - Fixed potential buffer overflow in `cupsCopyDestConflicts`.
+- Added new PWG media sizes.
 
 
 v3.0.2 - 2026-06-05

--- a/cups/pwg-media.c
+++ b/cups/pwg-media.c
@@ -266,6 +266,14 @@ static pwg_media_t const cups_pwg_media[] =
   _PWG_MEDIA_MM("prc_6_120x320mm", NULL, NULL, 120, 320),
   _PWG_MEDIA_MM("prc_7_160x230mm", NULL, "EnvPRC7", 160, 230),
   // prc_10 is iso_c3_324x458mm.
+  _PWG_MEDIA_MM("prc_d0_764x1064mm", NULL, "PRCD0", 764, 1064),
+  _PWG_MEDIA_MM("prc_d1_532x760mm", NULL, "PRCD1", 532, 760),
+  _PWG_MEDIA_MM("prc_d2_380x528mm", NULL, "PRCD2", 380, 528),
+  _PWG_MEDIA_MM("prc_d3_264x376mm", NULL, "PRCD3", 264, 376),
+  _PWG_MEDIA_MM("prc_d4_188x260mm", NULL, "PRCD4", 188, 260),
+  _PWG_MEDIA_MM("prc_d5_130x184mm", NULL, "PRCD5", 130, 184),
+  _PWG_MEDIA_MM("prc_d6_92x126mm", NULL, "PRCD6", 92, 126),
+  _PWG_MEDIA_MM("prc_zl_120x230mm", NULL, "PRCZL", 120, 230),
 
   // Chinese Standard Sheet Media Inch Sizes
   _PWG_MEDIA_IN("roc_16k_7.75x10.75in", NULL, "roc16k", 7.75, 10.75),


### PR DESCRIPTION
This pull request adds PWG media sizes for PRC D0-D6 and PRC ZL.

References:

- GB/T 148-2026 standard text: https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=EB3ABA24014A3C55ED4BF88B0BB8DD22 (Chinese, pay-walled)
- GB/T 1416-2021 standard text: http://c.gb688.cn/bzgk/gb/showGb?type=online&hcno=DE308FCC68F31C0B7C6F169AA5BFA593 (Chinese, free PDF download)
- PWG errata: https://www.pwg.org/dynamo/issues.php?L140+P-1+S-2+I0+E0+Z81+Q
- `libpaper` pull request: https://github.com/rrthomas/libpaper/pull/64
- `cups` pull request: https://github.com/OpenPrinting/cups/pull/1635