### PR TITLE
add httpFieldName function

### DIFF
--- a/cups/http.c
+++ b/cups/http.c
@@ -639,6 +639,18 @@ httpFieldValue(const char *name)	// I - String name
   return (HTTP_FIELD_UNKNOWN);
 }
 
+//
+// 'httpFieldName()' - Return the field name for a HTTP field enumeration.
+//
+
+const char *				// O - Field name
+httpFieldName(http_field_t field)	// I - Field index
+{
+  if (field >= HTTP_FIELD_ACCEPT && field < HTTP_FIELD_MAX)
+    return (http_fields[field]);
+  else
+    return (NULL);
+}
 
 //
 // 'httpFlush()' - Flush data read from a HTTP connection.

--- a/cups/http.c
+++ b/cups/http.c
@@ -640,11 +640,11 @@ httpFieldValue(const char *name)	// I - String name
 }
 
 //
-// 'httpFieldName()' - Return the field name for a HTTP field enumeration.
+// 'httpFieldString()' - Return the field name for a HTTP field enumeration.
 //
 
 const char *				// O - Field name
-httpFieldName(http_field_t field)	// I - Field index
+httpFieldString(http_field_t field)	// I - Field index
 {
   if (field >= HTTP_FIELD_ACCEPT && field < HTTP_FIELD_MAX)
     return (http_fields[field]);

--- a/cups/http.h
+++ b/cups/http.h
@@ -445,7 +445,7 @@ extern char		*httpDecode64(char *out, size_t *outlen, const char *in, const char
 extern char		*httpEncode64(char *out, size_t outlen, const char *in, size_t inlen, bool url) _CUPS_PUBLIC;
 
 extern http_field_t	httpFieldValue(const char *name) _CUPS_PUBLIC;
-extern const char	*httpFieldName(http_field_t field) _CUPS_PUBLIC;
+extern const char	*httpFieldString(http_field_t field) _CUPS_PUBLIC;
 extern void		httpFlush(http_t *http) _CUPS_PUBLIC;
 extern int		httpFlushWrite(http_t *http) _CUPS_PUBLIC;
 

--- a/cups/http.h
+++ b/cups/http.h
@@ -445,6 +445,7 @@ extern char		*httpDecode64(char *out, size_t *outlen, const char *in, const char
 extern char		*httpEncode64(char *out, size_t outlen, const char *in, size_t inlen, bool url) _CUPS_PUBLIC;
 
 extern http_field_t	httpFieldValue(const char *name) _CUPS_PUBLIC;
+extern const char	*httpFieldName(http_field_t field) _CUPS_PUBLIC;
 extern void		httpFlush(http_t *http) _CUPS_PUBLIC;
 extern int		httpFlushWrite(http_t *http) _CUPS_PUBLIC;
 

--- a/cups/libcups3.def
+++ b/cups/libcups3.def
@@ -375,7 +375,7 @@ httpCopyPeerCredentials
 httpDecode64
 httpEncode64
 httpFieldValue
-httpFieldName
+httpFieldString
 httpFlush
 httpFlushWrite
 httpGetActivity

--- a/cups/libcups3.def
+++ b/cups/libcups3.def
@@ -375,6 +375,7 @@ httpCopyPeerCredentials
 httpDecode64
 httpEncode64
 httpFieldValue
+httpFieldName
 httpFlush
 httpFlushWrite
 httpGetActivity


### PR DESCRIPTION
I added a new `httpFieldName()` function to convert a `http_field_t` value to its corresponding HTTP header name. 

This complements httpFieldValue(), providing bidirectional conversion between HTTP header names and http_field_t values and it will simplify libcups integration.