### PR TITLE
Fix media-col-database test

### DIFF
--- a/examples/get-printer-attributes-suite.test
+++ b/examples/get-printer-attributes-suite.test
@@ -265,7 +265,7 @@ VERSION 2.0
 	ATTR charset attributes-charset utf-8
 	ATTR language attributes-natural-language en
 	ATTR uri printer-uri $uri
-	ATTR keyword requested-attributes 'all'
+	ATTR keyword requested-attributes 'media-col-database'
 
 	STATUS successful-ok
 


### PR DESCRIPTION
The test `"Get-Printer-Attributes (requested-attributes='media-col-database')"` actually defines the "request-attributes" as "all" instead of "media-col-database"