### PR TITLE
fix over-read in cups_auth_scheme/param/find on unterminated quote

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ v3.0.3 - YYYY-MM-DD
 - Updated the configure script to look for PDFio v1.2 or later.
 - Fixed a non-blocking IO bug that impacted GNOME.
 - Fixed a potential buffer overflow in `cupsFormEncode`.
+- Fixed a buffer over-read when parsing a `WWW-Authenticate` header containing an
+  unterminated quoted value.
 - Fixed long number string error handling in `cupsJSONImportXxx`.
 - Fixed HTTP state for POST/PUT with an empty message body (Issue #149)
 - Fixed the example RPM spec file (Issue #150)

--- a/cups/auth.c
+++ b/cups/auth.c
@@ -262,7 +262,8 @@ cups_auth_find(const char *www_authenticate,	// I - Pointer into WWW-Authenticat
         DEBUG_printf("9cups_auth_find: After quoted: \"%s\"", www_authenticate);
       }
 
-      www_authenticate ++;
+      if (*www_authenticate)
+        www_authenticate ++;
     }
 
     DEBUG_printf("9cups_auth_find: After skip: \"%s\"", www_authenticate);
@@ -352,7 +353,8 @@ cups_auth_param(const char *scheme,		// I - Pointer to auth data
           scheme ++;
       }
 
-      scheme ++;
+      if (*scheme)
+        scheme ++;
     }
 
     // If this wasn't a parameter, we are at the end of this scheme's
@@ -415,6 +417,9 @@ cups_auth_scheme(const char *www_authenticate,	// I - Pointer into WWW-Authentic
           www_authenticate ++;
         }
         while (*www_authenticate && *www_authenticate != '\"');
+
+        if (!*www_authenticate)
+          break;
       }
     }
 


### PR DESCRIPTION
The three helpers in `auth.c` that walk the `WWW-Authenticate` header all skip a quoted parameter value the same way: step forward until the closing quote or the end of the string, then advance one more. If the server never closes the quote, that last advance lands past the NUL of the strdup'd field buffer, and the enclosing loop keeps dereferencing heap past the allocation until it happens to trip over a NUL or a space, so whatever sits after it can end up in the parsed scheme name or `realm`. I noticed it reading the quoted-value handling and comparing it against `httpGetSubField`, which guards the same step with `if (*fptr) fptr ++;` while these three do not. `cups_auth_scheme` and `cups_auth_param` are on the path for any 401 response, `cups_auth_find` for the `PeerCred` check over a domain socket. Guarding the advance the same way covers all three sites. With `realm="unterminated` as the whole header value asan reports heap-buffer-overflow reads at `auth.c:400`, `:341` and `:253` before the change and nothing after, and `make test` still scores 100%.